### PR TITLE
looks like colqwen 2.5 omni support was accidentally removed

### DIFF
--- a/colpali_engine/__init__.py
+++ b/colpali_engine/__init__.py
@@ -16,7 +16,7 @@ from .models import (
     ColQwen2,
     ColQwen2_5,
     ColQwen2_5_Processor,
-    # ColQwen2_5Omni,
-    # ColQwen2_5OmniProcessor,
+    ColQwen2_5Omni,
+    ColQwen2_5OmniProcessor,
     ColQwen2Processor,
 )

--- a/colpali_engine/models/__init__.py
+++ b/colpali_engine/models/__init__.py
@@ -3,3 +3,4 @@ from .modernvbert import BiModernVBert, BiModernVBertProcessor, ColModernVBert, 
 from .paligemma import BiPali, BiPaliProcessor, BiPaliProj, ColPali, ColPaliProcessor
 from .qwen2 import BiQwen2, BiQwen2Processor, ColQwen2, ColQwen2Processor
 from .qwen2_5 import BiQwen2_5, BiQwen2_5_Processor, ColQwen2_5, ColQwen2_5_Processor
+from .qwen_omni import ColQwen2_5Omni, ColQwen2_5OmniProcessor

--- a/colpali_engine/models/qwen_omni/__init__.py
+++ b/colpali_engine/models/qwen_omni/__init__.py
@@ -1,0 +1,1 @@
+from .colqwen_omni import ColQwen2_5Omni, ColQwen2_5OmniProcessor

--- a/colpali_engine/models/qwen_omni/colqwen_omni/__init__.py
+++ b/colpali_engine/models/qwen_omni/colqwen_omni/__init__.py
@@ -1,0 +1,2 @@
+from .modeling_colqwen_omni import ColQwen2_5Omni
+from .processing_colqwen_omni import ColQwen2_5OmniProcessor


### PR DESCRIPTION
 in https://github.com/illuin-tech/colpali/pull/339

EDIT: that was based upon just looking at the main __init__.py. looking at the other files, perhaps it was intentionally removed...